### PR TITLE
Feature/intial default implementation

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/MetadataPersistenceConfig.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/MetadataPersistenceConfig.java
@@ -1,0 +1,31 @@
+package net.smartcosmos.dao.metadata;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.orm.jpa.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.format.FormatterRegistrar;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import java.util.Map;
+
+@EnableJpaRepositories
+@EnableJpaAuditing
+@EntityScan
+@ComponentScan
+@Configuration
+public class MetadataPersistenceConfig extends WebMvcConfigurerAdapter {
+
+    @Autowired
+    Map<String, FormatterRegistrar> formatterRegistrarMap;
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        for (FormatterRegistrar registrar : formatterRegistrarMap.values()) {
+            registrar.registerFormatters(registry);
+        }
+    }
+}

--- a/src/main/java/net/smartcosmos/dao/metadata/converter/MetadataEntityToMetadataResponseConverter.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/converter/MetadataEntityToMetadataResponseConverter.java
@@ -1,0 +1,46 @@
+package net.smartcosmos.dao.metadata.converter;
+
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import net.smartcosmos.dto.metadata.MetadataResponse;
+import net.smartcosmos.util.UuidUtil;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistrar;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MetadataEntityToMetadataResponseConverter implements Converter<MetadataEntity, MetadataResponse>, FormatterRegistrar {
+
+    @Override
+    public MetadataResponse convert(MetadataEntity entity) {
+
+        return MetadataResponse.builder()
+            .urn(UuidUtil.getUrnFromUuid(entity.getId()))
+            .entityReferenceType(entity.getEntityReferenceType())
+            .referenceUrn(UuidUtil.getUrnFromUuid(entity.getReferenceId()))
+            .key(entity.getKey())
+            .dataType(entity.getDataType())
+            .rawValue(entity.getRawValue())
+            .moniker(entity.getMoniker())
+            .lastModifiedTimestamp(entity.getLastModified())
+            .build();
+    }
+
+    public List convertAll(Iterable<MetadataEntity> entities) {
+
+        List<MetadataResponse> convertedList = new ArrayList<>();
+        for (MetadataEntity entity : entities) {
+            convertedList.add(convert(entity));
+        }
+
+        return convertedList;
+    }
+
+    @Override
+    public void registerFormatters(FormatterRegistry registry) {
+        registry.addConverter(this);
+    }
+}

--- a/src/main/java/net/smartcosmos/dao/metadata/converter/MetadataUpsertToMetadataEntityConverter.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/converter/MetadataUpsertToMetadataEntityConverter.java
@@ -2,8 +2,6 @@ package net.smartcosmos.dao.metadata.converter;
 
 import net.smartcosmos.dao.metadata.domain.MetadataEntity;
 import net.smartcosmos.dto.metadata.MetadataUpsert;
-import net.smartcosmos.security.user.SmartCosmosUser;
-import net.smartcosmos.security.user.SmartCosmosUserHolder;
 import net.smartcosmos.util.UuidUtil;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.format.FormatterRegistrar;
@@ -18,11 +16,7 @@ public class MetadataUpsertToMetadataEntityConverter implements Converter<Metada
     @Override
     public MetadataEntity convert(MetadataUpsert entity) {
 
-        // Retrieve current user.
-        SmartCosmosUser user = SmartCosmosUserHolder.getCurrentUser();
-
         return MetadataEntity.builder()
-            .accountId(UuidUtil.getUuidFromAccountUrn(user.getAccountUrn()))
             .entityReferenceType(entity.getEntityReferenceType())
             .referenceId(UuidUtil.getUuidFromUrn(entity.getReferenceUrn()))
             .dataType(entity.getDataType())

--- a/src/main/java/net/smartcosmos/dao/metadata/converter/MetadataUpsertToMetadataEntityConverter.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/converter/MetadataUpsertToMetadataEntityConverter.java
@@ -1,0 +1,49 @@
+package net.smartcosmos.dao.metadata.converter;
+
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import net.smartcosmos.dto.metadata.MetadataUpsert;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import net.smartcosmos.security.user.SmartCosmosUserHolder;
+import net.smartcosmos.util.UuidUtil;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistrar;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MetadataUpsertToMetadataEntityConverter implements Converter<MetadataUpsert, MetadataEntity>, FormatterRegistrar {
+    @Override
+    public MetadataEntity convert(MetadataUpsert entity) {
+
+        // Retrieve current user.
+        SmartCosmosUser user = SmartCosmosUserHolder.getCurrentUser();
+
+        return MetadataEntity.builder()
+            .accountId(UuidUtil.getUuidFromAccountUrn(user.getAccountUrn()))
+            .entityReferenceType(entity.getEntityReferenceType())
+            .referenceId(UuidUtil.getUuidFromUrn(entity.getReferenceUrn()))
+            .dataType(entity.getDataType())
+            .key(entity.getKey())
+            .rawValue(entity.getRawValue())
+            .moniker(entity.getMoniker())
+            .build();
+    }
+
+    public List convertAll(Iterable<MetadataUpsert> entities) {
+
+        List<MetadataEntity> convertedList = new ArrayList<>();
+        for (MetadataUpsert entity : entities) {
+            convertedList.add(convert(entity));
+        }
+
+        return convertedList;
+    }
+
+    @Override
+    public void registerFormatters(FormatterRegistry registry) {
+        registry.addConverter(this);
+    }
+}

--- a/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
@@ -1,0 +1,81 @@
+package net.smartcosmos.dao.metadata.domain;
+
+import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Type;
+import org.hibernate.validator.constraints.NotEmpty;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.UUID;
+
+@Entity(name = "metadata")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+@Data
+@EntityListeners({ AuditingEntityListener.class })
+@Table(name = "metadata", uniqueConstraints = @UniqueConstraint(columnNames = { "systemUuid", "accountUuid" }) )
+public class MetadataEntity {
+
+    private static final int UUID_LENGTH = 16;
+    private static final int KEY_LENGTH = 255;
+    private static final int DATA_TYPE_LENGTH = 255;
+    private static final int ENTITY_REFERENCE_TYPE_LENGTH = 255;
+    private static final int RAW_VALUE_LENGTH = 767;
+    private static final int MONIKER_LENGTH = 2048;
+
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Type(type = "uuid-binary")
+    @Column(name = "systemUuid", length = UUID_LENGTH)
+    private UUID id;
+
+    @NotNull
+    @Type(type = "uuid-binary")
+    @Column(name = "accountUuid", length = UUID_LENGTH, nullable = false, updatable = false)
+    private UUID accountId;
+
+    @Size(max = DATA_TYPE_LENGTH)
+    @Column(name = "dataType", length = DATA_TYPE_LENGTH, nullable = true, updatable = true)
+    private String dataType;
+
+    @NotEmpty
+    @Size(max = ENTITY_REFERENCE_TYPE_LENGTH)
+    @Column(name = "entityReferenceType", length = DATA_TYPE_LENGTH, nullable = false, updatable = false)
+    private String entityReferenceType;
+
+    @NotNull
+    @Type(type = "uuid-binary")
+    @Column(name = "referenceUuid", length = UUID_LENGTH, nullable = false, updatable = false)
+    private UUID referenceId;
+
+    @NotEmpty
+    @Size(max = KEY_LENGTH)
+    @Column(name = "metadata_key", length = KEY_LENGTH, nullable = false, updatable = false)
+    private String key;
+
+    @NotEmpty
+    @Size(max = RAW_VALUE_LENGTH)
+    @Column(name = "rawValue", length = RAW_VALUE_LENGTH, nullable = false, updatable = true)
+    protected String rawValue;
+
+    @CreatedDate
+    @Column(name = "createdTimestamp", insertable = true, updatable = false)
+    private Long created;
+
+    @LastModifiedDate
+//    @Column(name = "lastModifiedTimestamp", insertable = false, updatable = true) // lastModified only set on update, might be used later
+    // lastModified already set on create (v2 compatibility)
+    @Column(name = "lastModifiedTimestamp", nullable = false, insertable = true, updatable = true)
+    private Long lastModified;
+
+    @Size(max = MONIKER_LENGTH)
+    @Column(name = "moniker", length = MONIKER_LENGTH, nullable = true, updatable = true)
+    private String moniker;
+}

--- a/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
@@ -63,7 +63,7 @@ public class MetadataEntity {
     @NotEmpty
     @Size(max = RAW_VALUE_LENGTH)
     @Column(name = "rawValue", length = RAW_VALUE_LENGTH, nullable = false, updatable = true)
-    protected String rawValue;
+    private String rawValue;
 
     @CreatedDate
     @Column(name = "createdTimestamp", insertable = true, updatable = false)

--- a/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
@@ -41,8 +41,9 @@ public class MetadataEntity {
     @Column(name = "accountUuid", length = UUID_LENGTH, nullable = false, updatable = false)
     private UUID accountId;
 
+    @NotEmpty
     @Size(max = DATA_TYPE_LENGTH)
-    @Column(name = "dataType", length = DATA_TYPE_LENGTH, nullable = true, updatable = true)
+    @Column(name = "dataType", length = DATA_TYPE_LENGTH, nullable = false, updatable = true)
     private String dataType;
 
     @NotEmpty

--- a/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
@@ -47,7 +47,7 @@ public class MetadataEntity {
 
     @NotEmpty
     @Size(max = ENTITY_REFERENCE_TYPE_LENGTH)
-    @Column(name = "entityReferenceType", length = DATA_TYPE_LENGTH, nullable = false, updatable = false)
+    @Column(name = "entityReferenceType", length = ENTITY_REFERENCE_TYPE_LENGTH, nullable = false, updatable = false)
     private String entityReferenceType;
 
     @NotNull

--- a/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
@@ -79,7 +79,28 @@ public class MetadataPersistenceService implements MetadataDao {
 
     @Override
     public Optional<MetadataResponse> findByKey(String accountUrn, String entityReferenceType, String referenceUrn, String key) {
-        return null;
+
+        UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
+
+        Optional<MetadataEntity> entity = Optional.empty();
+        try {
+            UUID uuid = UuidUtil.getUuidFromUrn(referenceUrn);
+            entity = metadataRepository.findByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(
+                accountId,
+                entityReferenceType,
+                uuid,
+                key);
+        } catch (IllegalArgumentException e) {
+            // empty Optional will be returned anyway
+            log.warn("Illegal URN submitted: %s by account %s", referenceUrn, accountUrn);
+        }
+
+        if (entity.isPresent())
+        {
+            final MetadataResponse response = conversionService.convert(entity.get(), MetadataResponse.class);
+            return Optional.ofNullable(response);
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
@@ -1,0 +1,44 @@
+package net.smartcosmos.dao.metadata.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import net.smartcosmos.dao.metadata.MetadataDao;
+import net.smartcosmos.dao.metadata.repository.MetadataRepository;
+import net.smartcosmos.dto.metadata.MetadataResponse;
+import net.smartcosmos.dto.metadata.MetadataUpsert;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.stereotype.Service;
+
+import javax.validation.ConstraintViolationException;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class MetadataPersistenceService implements MetadataDao {
+
+    private final MetadataRepository metadataRepository;
+    private final ConversionService conversionService;
+
+    @Autowired
+    public MetadataPersistenceService(MetadataRepository metadataRepository,
+                                      ConversionService conversionService) {
+        this.metadataRepository = metadataRepository;
+        this.conversionService = conversionService;
+    }
+
+    @Override
+    public List<MetadataResponse> upsert(String accountUrn, String entityReferenceType, String referenceUrn, List<MetadataUpsert> metadataUpsertList) throws ConstraintViolationException {
+        return null;
+    }
+
+    @Override
+    public Optional<MetadataResponse> delete(String accountUrn, String entityReferenceType, String referenceUrn, String key) {
+        return null;
+    }
+
+    @Override
+    public Optional<MetadataResponse> findByKey(String accountUrn, String entityReferenceType, String referenceUrn, String key) {
+        return null;
+    }
+}

--- a/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
@@ -1,17 +1,20 @@
 package net.smartcosmos.dao.metadata.impl;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import javax.validation.ConstraintViolationException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.stereotype.Service;
+
 import lombok.extern.slf4j.Slf4j;
 import net.smartcosmos.dao.metadata.MetadataDao;
 import net.smartcosmos.dao.metadata.repository.MetadataRepository;
 import net.smartcosmos.dto.metadata.MetadataResponse;
 import net.smartcosmos.dto.metadata.MetadataUpsert;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.convert.ConversionService;
-import org.springframework.stereotype.Service;
-
-import javax.validation.ConstraintViolationException;
-import java.util.List;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -28,7 +31,7 @@ public class MetadataPersistenceService implements MetadataDao {
     }
 
     @Override
-    public List<MetadataResponse> upsert(String accountUrn, String entityReferenceType, String referenceUrn, List<MetadataUpsert> metadataUpsertList) throws ConstraintViolationException {
+    public List<MetadataResponse> upsert(String accountUrn, String entityReferenceType, String referenceUrn, Collection<MetadataUpsert> metadataUpsertList) throws ConstraintViolationException {
         return null;
     }
 

--- a/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
@@ -53,12 +53,11 @@ public class MetadataPersistenceService implements MetadataDao {
     @Override
     public List<MetadataResponse> delete(String accountUrn, String entityReferenceType, String referenceUrn, String key) {
 
+        UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
         List<MetadataEntity> deleteList = new ArrayList<>();
 
         try {
-            UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
             UUID referenceId = UuidUtil.getUuidFromUrn(referenceUrn);
-
             deleteList = metadataRepository.deleteByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(
                 accountId,
                 entityReferenceType,
@@ -67,9 +66,6 @@ public class MetadataPersistenceService implements MetadataDao {
         } catch (IllegalArgumentException e) {
             // empty list will be returned anyway
             log.warn("Illegal URN submitted: %s by account %s", referenceUrn, accountUrn);
-
-            // TODO: Returning an empty list here will hide the fact that there was a problem with URNs - do we really want that?
-            // It would mean both then: (1) Did not find what you attempted to delete, and (2) invalid URN
         }
 
         return deleteList.stream()

--- a/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
@@ -1,20 +1,22 @@
 package net.smartcosmos.dao.metadata.impl;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-
-import javax.validation.ConstraintViolationException;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.convert.ConversionService;
-import org.springframework.stereotype.Service;
-
 import lombok.extern.slf4j.Slf4j;
 import net.smartcosmos.dao.metadata.MetadataDao;
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
 import net.smartcosmos.dao.metadata.repository.MetadataRepository;
 import net.smartcosmos.dto.metadata.MetadataResponse;
 import net.smartcosmos.dto.metadata.MetadataUpsert;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.TransactionException;
+
+import javax.validation.ConstraintViolationException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -31,8 +33,18 @@ public class MetadataPersistenceService implements MetadataDao {
     }
 
     @Override
-    public List<MetadataResponse> upsert(String accountUrn, String entityReferenceType, String referenceUrn, Collection<MetadataUpsert> metadataUpsertList) throws ConstraintViolationException {
-        return null;
+    public List<MetadataResponse> upsert(String accountUrn, Collection<MetadataUpsert> upsertMetadataCollection) throws ConstraintViolationException {
+
+        List<MetadataResponse> responseList = new ArrayList<>();
+
+        for (MetadataUpsert upsertMetadata : upsertMetadataCollection) {
+            MetadataEntity entity = conversionService.convert(upsertMetadata, MetadataEntity.class);
+            entity = persist(entity);
+
+            responseList.add(conversionService.convert(entity, MetadataResponse.class));
+        }
+
+        return responseList;
     }
 
     @Override
@@ -43,5 +55,28 @@ public class MetadataPersistenceService implements MetadataDao {
     @Override
     public Optional<MetadataResponse> findByKey(String accountUrn, String entityReferenceType, String referenceUrn, String key) {
         return null;
+    }
+
+    /**
+     * Saves an metadata entity in an {@link MetadataRepository}.
+     *
+     * @param metadataEntity the metadata entity to persist
+     * @return the persisted metadata entity
+     * @throws ConstraintViolationException if the transaction fails due to violated constraints
+     * @throws TransactionException if the transaction fails because of something else
+     */
+    @SuppressWarnings("Duplicates")
+    private MetadataEntity persist(MetadataEntity metadataEntity) throws ConstraintViolationException, TransactionException {
+        try {
+            return metadataRepository.save(metadataEntity);
+        } catch (TransactionException e) {
+            // we expect constraint violations to be the root cause for exceptions here,
+            // so we throw this particular exception back to the caller
+            if (ExceptionUtils.getRootCause(e) instanceof ConstraintViolationException) {
+                throw (ConstraintViolationException) ExceptionUtils.getRootCause(e);
+            } else {
+                throw e;
+            }
+        }
     }
 }

--- a/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
@@ -37,8 +37,11 @@ public class MetadataPersistenceService implements MetadataDao {
 
         List<MetadataResponse> responseList = new ArrayList<>();
 
+        UUID accountId = UuidUtil.getUuidFromAccountUrn(accountUrn);
+
         for (MetadataUpsert upsertMetadata : upsertMetadataCollection) {
             MetadataEntity entity = conversionService.convert(upsertMetadata, MetadataEntity.class);
+            entity.setAccountId(accountId);
             entity = persist(entity);
 
             responseList.add(conversionService.convert(entity, MetadataResponse.class));

--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
@@ -1,0 +1,14 @@
+package net.smartcosmos.dao.metadata.repository;
+
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MetadataRepository extends JpaRepository<MetadataEntity, UUID> {
+
+    @Transactional
+    List<MetadataEntity> deleteByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(UUID accountId, String entityReferenceType, UUID referenceId, String key);
+}

--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
@@ -5,11 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MetadataRepository extends JpaRepository<MetadataEntity, UUID> {
 
     List<MetadataEntity> findByAccountIdAndReferenceId(UUID accountId, UUID referenceId);
+
+    Optional<MetadataEntity> findByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(UUID accountId, String entityReferenceType, UUID referenceId, String key);
 
     @Transactional
     List<MetadataEntity> deleteByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(UUID accountId, String entityReferenceType, UUID referenceId, String key);

--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 
 public interface MetadataRepository extends JpaRepository<MetadataEntity, UUID> {
 
+    List<MetadataEntity> findByAccountIdAndReferenceId(UUID accountId, UUID referenceId);
+
     @Transactional
     List<MetadataEntity> deleteByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(UUID accountId, String entityReferenceType, UUID referenceId, String key);
 }

--- a/src/test/java/net/smartcosmos/dao/metadata/MetadataPersistenceTestApplication.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/MetadataPersistenceTestApplication.java
@@ -1,0 +1,9 @@
+package net.smartcosmos.dao.metadata;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+@EnableAutoConfiguration
+@Configuration
+public class MetadataPersistenceTestApplication {
+}

--- a/src/test/java/net/smartcosmos/dao/metadata/domain/MetadataEntityTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/domain/MetadataEntityTest.java
@@ -1,0 +1,19 @@
+package net.smartcosmos.dao.metadata.domain;
+
+import org.junit.BeforeClass;
+
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+@SuppressWarnings("Duplicates")
+public class MetadataEntityTest {
+
+    private static Validator validator;
+
+    @BeforeClass
+    public static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+}

--- a/src/test/java/net/smartcosmos/dao/metadata/domain/MetadataEntityTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/domain/MetadataEntityTest.java
@@ -1,19 +1,454 @@
 package net.smartcosmos.dao.metadata.domain;
 
+import net.smartcosmos.util.UuidUtil;
+import org.apache.commons.lang.RandomStringUtils;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("Duplicates")
 public class MetadataEntityTest {
 
     private static Validator validator;
 
+    private static final UUID ID = UuidUtil.getNewUuid();
+    private static final UUID ACCOUNT_ID = UuidUtil.getNewUuid();
+    private static final String DATA_TYPE = "StringType";
+    private static final String DATA_TYPE_INVALID = RandomStringUtils.randomAlphanumeric(256);
+    private static final String ENTITY_REFERENCE_TYPE = "Object";
+    private static final String ENTITY_REFERENCE_TYPE_INVALID = RandomStringUtils.randomAlphanumeric(256);
+    private static final UUID REFERENCE_ID = UuidUtil.getNewUuid();
+    private static final String KEY = RandomStringUtils.randomAlphanumeric(255);
+    private static final String KEY_INVALID = RandomStringUtils.randomAlphanumeric(256);
+    private static final String RAW_VALUE = RandomStringUtils.randomAlphanumeric(767);
+    private static final String RAW_VALUE_INVALID = RandomStringUtils.randomAlphanumeric(768);
+    private static final String MONIKER = RandomStringUtils.randomAlphanumeric(2048);
+    private static final String MONIKER_INVALID = RandomStringUtils.randomAlphanumeric(2049);
+
     @BeforeClass
     public static void setUp() {
         ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
         validator = factory.getValidator();
     }
+
+    @Test
+    public void thatEverythingIsOk() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertTrue(violationSet.isEmpty());
+    }
+
+    @Test
+    public void thatAccountIdIsNotNull() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+//            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{javax.validation.constraints.NotNull.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("accountId", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    // region Data Type
+
+    @Test
+    public void thatDataTypeIsNotNull() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+//            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("dataType", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatDataTypeIsNotEmpty() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType("")
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("dataType", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatDataTypeInvalidFails() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE_INVALID)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{javax.validation.constraints.Size.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("dataType", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    // endregion
+
+    // region Entity Reference Type
+
+    @Test
+    public void thatEntityReferenceTypeIsNotNull() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+//            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("entityReferenceType", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatEntityReferenceTypeIsNotEmpty() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType("")
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("entityReferenceType", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatEntityReferenceTypeInvalidFails() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE_INVALID)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{javax.validation.constraints.Size.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("entityReferenceType", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    // endregion
+
+    // region Reference ID
+
+    @Test
+    public void thatReferenceIdIsNotNull() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+//            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{javax.validation.constraints.NotNull.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("referenceId", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    // endregion
+
+    // region Key
+
+    @Test
+    public void thatKeyIsNotNull() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+//            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("key", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatKeyIsNotEmpty() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key("")
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("key", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatKeyInvalidFails() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY_INVALID)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{javax.validation.constraints.Size.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("key", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    // endregion
+
+    // region Raw Value
+
+    @Test
+    public void thatRawValueIsNotNull() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+//            .rawValue(RAW_VALUE)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("rawValue", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatRawValueIsNotEmpty() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue("")
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{org.hibernate.validator.constraints.NotEmpty.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("rawValue", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    @Test
+    public void thatRawValueInvalidFails() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE_INVALID)
+            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{javax.validation.constraints.Size.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("rawValue", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    // endregion
+
+    // region Moniker
+
+    @Test
+    public void thatMonikerMayBeNull() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+//            .moniker(MONIKER)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertTrue(violationSet.isEmpty());
+    }
+
+    @Test
+    public void thatMonikerMayBeEmpty() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker("")
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertTrue(violationSet.isEmpty());
+    }
+
+    @Test
+    public void thatMonikerInvalidFails() {
+
+        MetadataEntity metadataEntity = MetadataEntity.builder()
+            .id(ID)
+            .accountId(ACCOUNT_ID)
+            .dataType(DATA_TYPE)
+            .entityReferenceType(ENTITY_REFERENCE_TYPE)
+            .referenceId(REFERENCE_ID)
+            .key(KEY)
+            .rawValue(RAW_VALUE)
+            .moniker(MONIKER_INVALID)
+            .build();
+
+        Set<ConstraintViolation<MetadataEntity>> violationSet = validator.validate(metadataEntity);
+
+        assertFalse(violationSet.isEmpty());
+        assertEquals(1, violationSet.size());
+        assertEquals("{javax.validation.constraints.Size.message}", violationSet.iterator().next().getMessageTemplate());
+        assertEquals("moniker", violationSet.iterator().next().getPropertyPath().toString());
+    }
+
+    // endregion
 }

--- a/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
@@ -24,13 +24,11 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("Duplicates")
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -141,5 +139,36 @@ public class MetadataPersistenceServiceTest {
         assertEquals(key, deleteList.get(0).getKey());
         assertEquals(dataType, deleteList.get(0).getDataType());
         assertEquals(rawValue, deleteList.get(0).getRawValue());
+    }
+
+    @Test
+    public void testFindByKey() {
+
+        final String key = "findMe";
+        final String dataType = "BooleanType";
+        final String rawValue = "true";
+        final String entityReferenceType = "Object";
+        final String referenceUrn = "urn:uuid:" + UuidUtil.getNewUuidAsString();
+
+        MetadataUpsert create = MetadataUpsert.builder()
+            .referenceUrn(referenceUrn)
+            .entityReferenceType(entityReferenceType)
+            .rawValue(rawValue)
+            .dataType(dataType)
+            .key(key)
+            .build();
+
+        List<MetadataUpsert> createList = new ArrayList<>();
+        createList.add(create);
+        metadataPersistenceService.upsert(accountUrn, createList);
+
+        Optional<MetadataResponse> response = metadataPersistenceService.findByKey(accountUrn, entityReferenceType, referenceUrn, key);
+
+        assertTrue(response.isPresent());
+        assertEquals(referenceUrn, response.get().getReferenceUrn());
+        assertEquals(entityReferenceType, response.get().getEntityReferenceType());
+        assertEquals(key, response.get().getKey());
+        assertEquals(dataType, response.get().getDataType());
+        assertEquals(rawValue, response.get().getRawValue());
     }
 }

--- a/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
@@ -26,9 +26,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @SuppressWarnings("Duplicates")
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -107,6 +105,71 @@ public class MetadataPersistenceServiceTest {
         assertEquals(key, entityList.get(0).getKey());
         assertEquals(dataType, entityList.get(0).getDataType());
         assertEquals(rawValue, entityList.get(0).getRawValue());
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+
+        final String key = "updateKey";
+        final String dataType = "BooleanType";
+        final String initialRawValue = "true";
+        final String updateRawValue = "false";
+        final String entityReferenceType = "Object";
+        final String referenceUrn = "urn:uuid:" + UuidUtil.getNewUuidAsString();
+
+        MetadataUpsert create = MetadataUpsert.builder()
+            .referenceUrn(referenceUrn)
+            .entityReferenceType(entityReferenceType)
+            .rawValue(initialRawValue)
+            .dataType(dataType)
+            .key(key)
+            .build();
+
+        List<MetadataUpsert> createList = new ArrayList<>();
+        createList.add(create);
+
+        List<MetadataResponse> createResponseList = metadataPersistenceService.upsert(accountUrn, createList);
+
+        assertFalse(createResponseList.isEmpty());
+        assertEquals(1, createResponseList.size());
+        assertEquals(referenceUrn, createResponseList.get(0).getReferenceUrn());
+        assertEquals(entityReferenceType, createResponseList.get(0).getEntityReferenceType());
+        assertEquals(key, createResponseList.get(0).getKey());
+        assertEquals(dataType, createResponseList.get(0).getDataType());
+        assertEquals(initialRawValue, createResponseList.get(0).getRawValue());
+
+        MetadataUpsert update = MetadataUpsert.builder()
+            .referenceUrn(referenceUrn)
+            .entityReferenceType(entityReferenceType)
+            .rawValue(updateRawValue)
+            .dataType(dataType)
+            .key(key)
+            .build();
+
+        List<MetadataUpsert> updateList = new ArrayList<>();
+        updateList.add(update);
+
+        List<MetadataResponse> updateResponseList = metadataPersistenceService.upsert(accountUrn, updateList);
+
+        assertFalse(updateResponseList.isEmpty());
+        assertEquals(1, updateResponseList.size());
+        assertEquals(referenceUrn, updateResponseList.get(0).getReferenceUrn());
+        assertEquals(entityReferenceType, updateResponseList.get(0).getEntityReferenceType());
+        assertEquals(key, updateResponseList.get(0).getKey());
+        assertEquals(dataType, updateResponseList.get(0).getDataType());
+        assertEquals(updateRawValue, updateResponseList.get(0).getRawValue());
+
+        List<MetadataEntity> entityList = metadataRepository.findByAccountIdAndReferenceId(accountId, UuidUtil.getUuidFromUrn(referenceUrn));
+
+        assertFalse(entityList.isEmpty());
+
+        assertFalse(entityList.isEmpty());
+        assertEquals(1, entityList.size());
+        assertEquals(referenceUrn, UuidUtil.getUrnFromUuid(entityList.get(0).getReferenceId()));
+        assertEquals(entityReferenceType, entityList.get(0).getEntityReferenceType());
+        assertEquals(key, entityList.get(0).getKey());
+        assertEquals(dataType, entityList.get(0).getDataType());
+        assertEquals(updateRawValue, entityList.get(0).getRawValue());
     }
 
     @Test

--- a/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
@@ -1,0 +1,61 @@
+package net.smartcosmos.dao.metadata.impl;
+
+import net.smartcosmos.dao.metadata.MetadataPersistenceConfig;
+import net.smartcosmos.dao.metadata.MetadataPersistenceTestApplication;
+import net.smartcosmos.dao.metadata.repository.MetadataRepository;
+import net.smartcosmos.security.user.SmartCosmosUser;
+import net.smartcosmos.util.UuidUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+@SuppressWarnings("Duplicates")
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { MetadataPersistenceTestApplication.class, MetadataPersistenceConfig.class })
+@ActiveProfiles("test")
+@WebAppConfiguration
+@IntegrationTest({ "spring.cloud.config.enabled=false", "eureka.client.enabled:false" })
+public class MetadataPersistenceServiceTest {
+
+    private final UUID accountId = UUID.randomUUID();
+    private final String accountUrn = UuidUtil.getAccountUrnFromUuid(accountId);
+
+    @Autowired
+    MetadataPersistenceService metadataPersistenceService;
+
+    @Autowired
+    MetadataRepository metadataRepository;
+
+    @Before
+    public void setUp() throws Exception {
+
+        // Need to mock out user for conversion service.
+        // Might be a good candidate for a test package util.
+        Authentication authentication = Mockito.mock(Authentication.class);
+        Mockito.when(authentication.getPrincipal())
+            .thenReturn(new SmartCosmosUser(accountUrn, "urn:userUrn", "username",
+                "password", Arrays.asList(new SimpleGrantedAuthority("USER"))));
+        SecurityContext securityContext = Mockito.mock(SecurityContext.class);
+        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        metadataRepository.deleteAll();
+    }
+}

--- a/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
@@ -15,10 +15,10 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 /**
  *
@@ -74,6 +74,17 @@ public class MetadataRepositoryTest {
         assertEquals("true", entity.getRawValue());
         assertEquals("BooleanType", entity.getDataType());
         assertEquals(key, entity.getKey());
+    }
+
+    @Test
+    public void thatFindByKeyIsSuccessful() throws Exception {
+        Optional<MetadataEntity> entity = metadataRepository.findByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(accountId, entityReferenceType, referenceId, key);
+
+        assertTrue(entity.isPresent());
+
+        assertEquals("true", entity.get().getRawValue());
+        assertEquals("BooleanType", entity.get().getDataType());
+        assertEquals(key, entity.get().getKey());
     }
 
 }

--- a/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
@@ -1,0 +1,79 @@
+package net.smartcosmos.dao.metadata.repository;
+
+import net.smartcosmos.dao.metadata.MetadataPersistenceConfig;
+import net.smartcosmos.dao.metadata.MetadataPersistenceTestApplication;
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import net.smartcosmos.util.UuidUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ *
+ * Sometimes these runtime created methods have issues that don't come up until they're
+ * actually called. It's a minor setback with Spring, one that just requires some diligent
+ * testing.
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = { MetadataPersistenceTestApplication.class, MetadataPersistenceConfig.class })
+@ActiveProfiles("test")
+@WebAppConfiguration
+@IntegrationTest({ "spring.cloud.config.enabled=false", "eureka.client.enabled:false" })
+public class MetadataRepositoryTest {
+
+    @Autowired
+    MetadataRepository metadataRepository;
+
+    final UUID accountId = UUID.randomUUID();
+    private UUID id;
+    private UUID referenceId;
+    private String entityReferenceType = "Object";
+    private String key = "test";
+
+
+    @Before
+    public void setUp() throws Exception {
+
+        referenceId = UuidUtil.getNewUuid();
+
+        MetadataEntity entity = MetadataEntity.builder()
+            .accountId(accountId)
+            .referenceId(referenceId)
+            .entityReferenceType(entityReferenceType)
+            .rawValue("true")
+            .dataType("BooleanType")
+            .key(key)
+            .build();
+
+        entity = metadataRepository.save(entity);
+        id = entity.getId();
+    }
+
+    @Test
+    public void thatDeleteIsSuccessful() throws Exception {
+
+        List<MetadataEntity> entityList = metadataRepository.deleteByAccountIdAndEntityReferenceTypeAndReferenceIdAndKey(accountId, entityReferenceType, referenceId, key);
+
+        assertFalse(entityList.isEmpty());
+        assertEquals(1, entityList.size());
+
+        MetadataEntity entity = entityList.get(0);
+
+        assertEquals("true", entity.getRawValue());
+        assertEquals("BooleanType", entity.getDataType());
+        assertEquals(key, entity.getKey());
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    #
+    # CREATE DATABASE devkit;  GRANT ALL PRIVILEGES ON devkit.* TO 'cosmos'@'localhost' IDENTIFIED BY 'dev';  FLUSH PRIVILEGES;
+    #
+#    url: jdbc:mysql://localhost/devkit?autoReconnect=true
+#    username: cosmos
+#    password: dev
+#    driver-class-name: org.mariadb.jdbc.Driver
+# XXX Super dangerous to let this get to production.
+  jpa:
+    hibernate:
+      ddl-auto: update


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds the basic implementation for the metadata persistence service, including
- converters and entity
- upsert (create and update)
- delete
- findByKey
### How is this patch documented?

Javadoc, code comments and the code itself.
### How was this patch tested?

Unit tests for persistence service and repository.
#### Depends On

Nothing not already merged.
