### PR TITLE
key row name reset to metadata_key, since key is a reserved word in SQL

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
@@ -64,7 +64,7 @@ public class MetadataEntity {
 
     @NotEmpty
     @Size(max = KEY_LENGTH)
-    @Column(name = KEY_FIELD_NAME, length = KEY_LENGTH, nullable = false, updatable = false)
+    @Column(name = "metadata_key", length = KEY_LENGTH, nullable = false, updatable = false)
     private String key;
 
     @NotEmpty


### PR DESCRIPTION
### What changes were proposed in this pull request?

SQL metadata key column renamed from key to metadata_key, since key is a reserved word in SQL.
This also conforms to the column naming in Objects v2.
### How is this patch documented?

One-word change to MetadataEntity.java
### How was this patch tested?

Service could not start before this change due to SQL syntax error in Hibernate-generated SQL,
and now the service starts up and creates the metadata table cleanly.
#### Depends On

Nothing.
