### PR TITLE
Remove suffix from created and lastModified column names

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/domain/MetadataEntity.java
@@ -64,10 +64,10 @@ public class MetadataEntity implements Serializable {
     private UUID tenantId;
 
     @CreatedDate
-    @Column(name = "createdTimestamp", insertable = true, updatable = false)
+    @Column(name = "created", insertable = true, updatable = false)
     private Long created;
 
     @LastModifiedDate
-    @Column(name = "lastModifiedTimestamp", nullable = false, insertable = true, updatable = true)
+    @Column(name = "lastModified", nullable = false, insertable = true, updatable = true)
     private Long lastModified;
 }


### PR DESCRIPTION
Just change column name to be consistent with the field name, as previously discussed for Metadata `keyName`.
