### PR TITLE
Use copy of the key-value pair map for processing

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryImpl.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryImpl.java
@@ -1,6 +1,7 @@
 package net.smartcosmos.dao.metadata.repository;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -150,11 +151,14 @@ public class MetadataRepositoryImpl implements MetadataRepositoryCustom {
         Path<MetadataEntity> tenantIdPath = root.get(OWNER_FIELD_NAME).get(TENANT_ID_FIELD_NAME);
         Path<MetadataEntity> keyNamePath = root.get(KEY_NAME_FIELD_NAME);
 
+        Map<String, Object> metadataMap = new HashMap<>();
+        metadataMap.putAll(keyValuePairs);
+
         Predicate tenantPredicate = builder.equal(tenantIdPath, tenantId);
         Predicate keyPredicate = keyNamePath.in(keyValuePairs.keySet());
         Predicate rootPredicate = builder.and(tenantPredicate, keyPredicate);
 
-        Subquery<MetadataEntity> keyValueQuery = getRecursiveSubQueries(criteriaQuery.subquery(MetadataEntity.class), root, keyValuePairs, rootPredicate);
+        Subquery<MetadataEntity> keyValueQuery = getRecursiveSubQueries(criteriaQuery.subquery(MetadataEntity.class), root, metadataMap, rootPredicate);
 
         return builder.in(root.get(OWNER_FIELD_NAME)).value(keyValueQuery);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When executed within an actual Metadata microservice, the key-set was built based on an empty map, because all key-value pairs have previously been removed in order to construct the sub-queries.

This empty set produced an SQL syntax error that prevented execution of the `count` query required for paging.

Now, the key-value pair map is copied, so that the original (complete) version is still available.
### How is this patch documented?

Code.
### How was this patch tested?

Postman.
#### Depends On

Nothing.
