### PR TITLE
Replace JSONObject.NULL by NullNode

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/util/MetadataValueParser.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/util/MetadataValueParser.java
@@ -2,6 +2,7 @@ package net.smartcosmos.dao.metadata.util;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import lombok.extern.slf4j.Slf4j;
 import net.smartcosmos.dao.metadata.domain.MetadataDataType;
 import net.smartcosmos.dao.metadata.domain.MetadataEntity;
@@ -53,7 +54,7 @@ public class MetadataValueParser {
                         log.warn("MetadataValueParser.parseValue: Error parsing JSON, returning String instead.");
                     }
                 case JSON_LITERAL_NULL:
-                    return JSONObject.NULL;
+                    return NullNode.getInstance();
 
                 case STRING:
                 default:
@@ -61,7 +62,7 @@ public class MetadataValueParser {
             }
         }
 
-        return JSONObject.NULL;
+        return NullNode.getInstance();
     }
 
     /**

--- a/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
@@ -1,32 +1,7 @@
 package net.smartcosmos.dao.metadata.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.*;
-import org.junit.runner.*;
-import org.mockito.*;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.IntegrationTest;
-import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.test.context.web.WebAppConfiguration;
-
 import net.smartcosmos.dao.metadata.MetadataPersistenceConfig;
 import net.smartcosmos.dao.metadata.MetadataPersistenceTestApplication;
 import net.smartcosmos.dao.metadata.SortOrder;
@@ -40,6 +15,26 @@ import net.smartcosmos.dto.metadata.MetadataResponse;
 import net.smartcosmos.dto.metadata.MetadataSingleResponse;
 import net.smartcosmos.dto.metadata.Page;
 import net.smartcosmos.security.user.SmartCosmosUser;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import java.util.*;
 
 import static org.junit.Assert.*;
 
@@ -127,7 +122,7 @@ public class MetadataPersistenceServiceTest {
         assertEquals(jsonObject.toString(), response.get().getMetadata().get("someJsonObject").toString());
         assertEquals(jsonArray.toString(), response.get().getMetadata().get("someJsonArray").toString());
         assertEquals(number, response.get().getMetadata().get("someNumber"));
-        assertEquals(JSONObject.NULL, response.get().getMetadata().get("someNull"));
+        assertEquals(NullNode.getInstance(), response.get().getMetadata().get("someNull"));
         assertEquals(text, response.get().getMetadata().get("someString"));
 
         List<MetadataEntity> entityList = metadataRepository.findByOwner_TenantIdAndOwner_TypeAndOwner_Id(tenantId, ownerType, UuidUtil.getUuidFromUrn(ownerUrn));

--- a/src/test/java/net/smartcosmos/dao/metadata/util/MetadataValueParserTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/util/MetadataValueParserTest.java
@@ -1,10 +1,10 @@
 package net.smartcosmos.dao.metadata.util;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import net.smartcosmos.dao.metadata.domain.MetadataDataType;
 import net.smartcosmos.dao.metadata.domain.MetadataEntity;
-import org.json.JSONObject;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -20,7 +20,7 @@ public class MetadataValueParserTest {
 
         Object o = MetadataValueParser.parseValue(entity);
 
-        assertEquals(JSONObject.NULL, o);
+        assertEquals(NullNode.getInstance(), o);
     }
 
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `org.json:json` version of the JSON NULL literal (`JSONObject.NULL`) is replaced by one from Jackson: `NullNode.getInstance()`.

With this change serialization of NULL literals doesn't require any Jackson ObjectMapper configuration changes, because the mapper is able to serialize NULL objects by default, but this seems to only apply to Java's `null` and the Jackson `NullNode` instance -- `JSONObject.NULL` is unknown, and the mapper can only configured to ignore this unknown node as an empty bean, which results in an empty JSON object in the serialized output: `{}`.

The use of Java's `null` object is not applicable, because we use `Optional` to return the value, and `Optional.ofNullable(null)` returns `Optional.empty()` while `Optional.of(null)` throws a `NullPointerException`.

This change resolves bug [OBJECTS-882](https://smartractechnology.atlassian.net/browse/OBJECTS-882).
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests. An corresponding test in Metadata RDAO will follow.
#### Depends On

Nothing.
