### PR TITLE
removed extraneous dependency on spring-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,10 +65,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
What changes were proposed in this pull request?

extraneous dependency on spring-core removed from pom.xml

How is this patch documented?

in code (pom.xml, specifically)

How was this patch tested?

still builds, all tests still run.

Depends On

nothing
