### PR TITLE
Add type to findAll and findByKeyValuePairs, return tenantUrn in URI …

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
@@ -1,17 +1,18 @@
 package net.smartcosmos.dao.metadata.repository;
 
-import net.smartcosmos.dao.metadata.domain.MetadataDataType;
-import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import net.smartcosmos.dao.metadata.domain.MetadataDataType;
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
 
 public interface MetadataRepository extends JpaRepository<MetadataEntity, UUID>, JpaSpecificationExecutor<MetadataEntity>, MetadataRepositoryCustom {
 
@@ -21,12 +22,13 @@ public interface MetadataRepository extends JpaRepository<MetadataEntity, UUID>,
 
     Optional<MetadataEntity> findByOwner_TenantIdAndOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(UUID tenantId, String ownerType, UUID ownerId, String keyName);
 
-    Page<MetadataEntity> findByOwner_TenantId(UUID ownerId, Pageable pageable);
+    Page<MetadataEntity> findByOwner_TenantIdAndOwner_Type(UUID ownerId, String ownerType, Pageable pageable);
 
     List<MetadataEntity> findByOwner_TenantIdAndOwner_TypeAndOwner_Id(UUID tenantId, String ownerType, UUID ownerId);
 
-    Page<MetadataEntity> findByOwner_TenantIdAndKeyNameAndDataTypeAndValue(UUID tenantId, String keyName, MetadataDataType dataType,
-                                                                           String value, Pageable pageable);
+    Page<MetadataEntity> findByOwner_TenantIdAndOwner_TypeAndKeyNameAndDataTypeAndValue(UUID tenantId, String ownerType, String keyName,
+                                                                                        MetadataDataType dataType,
+                                                                                        String value, Pageable pageable);
 
     @Transactional
     List<MetadataEntity> deleteByOwner_TenantIdAndOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(UUID tenantId, String ownerType, UUID ownerId, String keyName);

--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryCustom.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryCustom.java
@@ -9,5 +9,9 @@ import java.util.UUID;
 
 public interface MetadataRepositoryCustom {
 
-    Page<MetadataOwnerEntity> findProjectedByTenantIdAndKeyValuePairs(UUID tenantId, Map<String, Object> keyValuePairs, Pageable pageable);
+    Page<MetadataOwnerEntity> findProjectedByTenantIdAndOwnerTypeAndKeyValuePairs(
+        UUID tenantId,
+        String ownerType,
+        Map<String, Object> keyValuePairs,
+        Pageable pageable);
 }

--- a/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
@@ -1,28 +1,22 @@
 package net.smartcosmos.dao.metadata.impl;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import net.smartcosmos.dao.metadata.MetadataPersistenceConfig;
-import net.smartcosmos.dao.metadata.MetadataPersistenceTestApplication;
-import net.smartcosmos.dao.metadata.SortOrder;
-import net.smartcosmos.dao.metadata.domain.MetadataDataType;
-import net.smartcosmos.dao.metadata.domain.MetadataEntity;
-import net.smartcosmos.dao.metadata.domain.MetadataOwnerEntity;
-import net.smartcosmos.dao.metadata.repository.MetadataRepository;
-import net.smartcosmos.dao.metadata.util.UuidUtil;
-import net.smartcosmos.dto.metadata.MetadataOwnerResponse;
-import net.smartcosmos.dto.metadata.MetadataResponse;
-import net.smartcosmos.dto.metadata.MetadataSingleResponse;
-import net.smartcosmos.dto.metadata.Page;
-import net.smartcosmos.security.user.SmartCosmosUser;
+
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -34,7 +28,20 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.util.*;
+import net.smartcosmos.dao.metadata.MetadataPersistenceConfig;
+import net.smartcosmos.dao.metadata.MetadataPersistenceTestApplication;
+import net.smartcosmos.dao.metadata.SortOrder;
+import net.smartcosmos.dao.metadata.domain.MetadataDataType;
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import net.smartcosmos.dao.metadata.domain.MetadataOwnerEntity;
+import net.smartcosmos.dao.metadata.repository.MetadataRepository;
+import net.smartcosmos.dao.metadata.util.UuidUtil;
+import net.smartcosmos.dto.metadata.MetadataOwnerResponse;
+import net.smartcosmos.dto.metadata.MetadataResponse;
+import net.smartcosmos.dto.metadata.MetadataSingleResponse;
+import net.smartcosmos.dto.metadata.MetadataValueResponse;
+import net.smartcosmos.dto.metadata.Page;
+import net.smartcosmos.security.user.SmartCosmosUser;
 
 import static org.junit.Assert.*;
 
@@ -273,10 +280,11 @@ public class MetadataPersistenceServiceTest {
         keyValues.put(keyName, value);
         metadataPersistenceService.create(tenantUrn, ownerType, ownerUrn, keyValues);
 
-        Optional<Object> o = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, keyName);
+        Optional<MetadataValueResponse> o = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, keyName);
 
         assertTrue(o.isPresent());
-        assertEquals(true, o.get());
+        assertEquals(true, o.get().getValue());
+        assertEquals(tenantUrn, o.get().getTenantUrn());
 
         Optional<MetadataResponse> response = metadataPersistenceService.update(tenantUrn, ownerType, ownerUrn, keyName, false);
 
@@ -289,7 +297,8 @@ public class MetadataPersistenceServiceTest {
         o = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, keyName);
 
         assertTrue(o.isPresent());
-        assertEquals(false, o.get());
+        assertEquals(false, o.get().getValue());
+        assertEquals(tenantUrn, o.get().getTenantUrn());
     }
 
     // endregion */
@@ -389,10 +398,11 @@ public class MetadataPersistenceServiceTest {
 
         metadataPersistenceService.create(tenantUrn, ownerType, ownerUrn, keyValues);
 
-        Optional<Object> response = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, keyName);
+        Optional<MetadataValueResponse> response = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, keyName);
 
         assertTrue(response.isPresent());
-        assertEquals(true, response.get());
+        assertEquals(true, response.get().getValue());
+        assertEquals(tenantUrn, response.get().getTenantUrn());
     }
 
     @Test
@@ -402,7 +412,7 @@ public class MetadataPersistenceServiceTest {
         final String ownerType = "Thing";
         final String ownerUrn = UuidUtil.getThingUrnFromUuid(UUID.randomUUID());
 
-        Optional<Object> response = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, keyName);
+        Optional<MetadataValueResponse> response = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, keyName);
 
         assertFalse(response.isPresent());
     }
@@ -487,7 +497,7 @@ public class MetadataPersistenceServiceTest {
 
     // endregion */
 
-    // region findAll
+    // region findByOwnerType
 
     @Test
     public void testFindByTypePaging() throws Exception {
@@ -500,7 +510,7 @@ public class MetadataPersistenceServiceTest {
         long expectedTotalSize = 12;
         long actualTotalSize = 0;
 
-        Page<MetadataSingleResponse> response = metadataPersistenceService.findAll(tenantUrn, 1, 3);
+        Page<MetadataSingleResponse> response = metadataPersistenceService.findByOwnerType(tenantUrn, "someOwner", 1, 3);
 
         assertNotNull(response);
         assertNotNull(response.getData());
@@ -546,7 +556,8 @@ public class MetadataPersistenceServiceTest {
         keyValuePairMap.put("fbK4", 12);
         keyValuePairMap.put("fbK2", "Test");
 
-        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByKeyValuePairs(tenantUrn, keyValuePairMap, 1, 10, null, null);
+        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByTypeAndKeyValuePairs(tenantUrn, "ownerType",
+            keyValuePairMap, 1, 10, null, null);
 
         assertEquals("urn:thing:uuid:89e0abc8-031f-4d89-8314-c8bf0a2b9913", responsePage.getData().get(0).getOwnerUrn());
 
@@ -575,20 +586,35 @@ public class MetadataPersistenceServiceTest {
         keyValuePairMap.put("key1", 12);
         keyValuePairMap.put("key2", 12);
 
-        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByKeyValuePairs(tenantUrn, keyValuePairMap, 1, 10, SortOrder.ASC,
+        Page<MetadataOwnerResponse> responsePageA = metadataPersistenceService.findOwnersByTypeAndKeyValuePairs(tenantUrn, "ownerA",
+            keyValuePairMap, 1, 10,
+            SortOrder.ASC,
             "ownerType");
 
-        assertEquals(2, responsePage.getData().size());
-        assertEquals(2, responsePage.getPage().getSize());
-        assertEquals(2, responsePage.getPage().getTotalElements());
+        assertEquals(1, responsePageA.getData().size());
+        assertEquals(1, responsePageA.getPage().getSize());
+        assertEquals(1, responsePageA.getPage().getTotalElements());
 
-        assertEquals(1, responsePage.getPage().getNumber());
-        assertEquals(1, responsePage.getPage().getTotalPages());
+        assertEquals(1, responsePageA.getPage().getNumber());
+        assertEquals(1, responsePageA.getPage().getTotalPages());
 
-        assertEquals(ownerUrn, responsePage.getData().get(0).getOwnerUrn());
-        assertEquals("ownerA", responsePage.getData().get(0).getOwnerType());
-        assertEquals(ownerUrn, responsePage.getData().get(1).getOwnerUrn());
-        assertEquals("ownerB", responsePage.getData().get(1).getOwnerType());
+        assertEquals(ownerUrn, responsePageA.getData().get(0).getOwnerUrn());
+        assertEquals("ownerA", responsePageA.getData().get(0).getOwnerType());
+
+        Page<MetadataOwnerResponse> responsePageB = metadataPersistenceService.findOwnersByTypeAndKeyValuePairs(tenantUrn, "ownerB",
+            keyValuePairMap, 1, 10,
+            SortOrder.ASC,
+            "ownerType");
+
+        assertEquals(1, responsePageB.getData().size());
+        assertEquals(1, responsePageB.getPage().getSize());
+        assertEquals(1, responsePageB.getPage().getTotalElements());
+
+        assertEquals(1, responsePageB.getPage().getNumber());
+        assertEquals(1, responsePageB.getPage().getTotalPages());
+
+        assertEquals(ownerUrn, responsePageB.getData().get(0).getOwnerUrn());
+        assertEquals("ownerB", responsePageB.getData().get(0).getOwnerType());
     }
 
     @Test
@@ -598,8 +624,8 @@ public class MetadataPersistenceServiceTest {
         keyValuePairMap.put("NoSuchKey", "NoSuchValue");
         keyValuePairMap.put("NoSuchKey2", "NoSuchValue2");
 
-        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByKeyValuePairs(tenantUrn, keyValuePairMap, 1, 10,
-            SortOrder.ASC, "ownerType");
+        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByTypeAndKeyValuePairs(tenantUrn, "someOwner",
+            keyValuePairMap, 1, 10, SortOrder.ASC, "ownerType");
 
         assertTrue(responsePage.getData().isEmpty());
 
@@ -609,42 +635,6 @@ public class MetadataPersistenceServiceTest {
 
         assertEquals(0,responsePage.getPage().getNumber());
         assertEquals(0,responsePage.getPage().getTotalPages());
-    }
-
-    @Test
-    public void testFindByKeyValuePairsSortedByOwnerType() throws Exception {
-
-        populateData();
-
-        final String[] ownerUrns = {
-            "urn:thing:uuid:c91b8b98-66da-4e0a-afaf-3ee28abc1dcf",
-            "urn:thing:uuid:53fef331-960f-4463-9061-1cf443d64df1",
-            "urn:thing:uuid:fb3c3f72-4fd4-4366-b100-3fa4e0e6e195"};
-
-        createMetadataEntity("ownerA", ownerUrns[0], "obO", 12);
-        createMetadataEntity("ownerA", ownerUrns[0], "obO2", 12);
-        createMetadataEntity("ownerC", ownerUrns[1], "obO", 12);
-        createMetadataEntity("ownerC", ownerUrns[1], "obO2", 12);
-        createMetadataEntity("ownerB", ownerUrns[2], "obO", 12);
-        createMetadataEntity("ownerB", ownerUrns[2], "obO2", 12);
-
-        Map<String, Object> keyValuePairMap = new HashMap<>();
-        keyValuePairMap.put("obO", 12);
-        keyValuePairMap.put("obO2", 12);
-
-        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByKeyValuePairs(tenantUrn, keyValuePairMap, 1, 10,
-            SortOrder.ASC, "ownerType");
-
-        assertEquals(ownerUrns[0], responsePage.getData().get(0).getOwnerUrn());
-        assertEquals(ownerUrns[2], responsePage.getData().get(1).getOwnerUrn());
-        assertEquals(ownerUrns[1], responsePage.getData().get(2).getOwnerUrn());
-
-        assertEquals(3, responsePage.getData().size());
-        assertEquals(3, responsePage.getPage().getSize());
-        assertEquals(3, responsePage.getPage().getTotalElements());
-
-        assertEquals(1, responsePage.getPage().getNumber());
-        assertEquals(1, responsePage.getPage().getTotalPages());
     }
 
     @Test
@@ -663,7 +653,8 @@ public class MetadataPersistenceServiceTest {
         Map<String, Object> keyValuePairMap = new HashMap<>();
         keyValuePairMap.put("single", "ABC");
 
-        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByKeyValuePairs(tenantUrn, keyValuePairMap, 1, 10, null, null);
+        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByTypeAndKeyValuePairs(tenantUrn,
+            "ownerType", keyValuePairMap, 1, 10, null, null);
 
         assertEquals(ownerUrns[0], responsePage.getData().get(0).getOwnerUrn());
         assertEquals(ownerUrns[1], responsePage.getData().get(1).getOwnerUrn());
@@ -677,48 +668,13 @@ public class MetadataPersistenceServiceTest {
     }
 
     @Test
-    public void testFindBySingleKeyValuePairDuplicateId() throws Exception {
-
-        populateData();
-
-        final String ownerUrn = "urn:thing:uuid:a420d9c1-4cca-4af7-955f-7b3382d19144";
-
-        createMetadataEntity("ownerD", ownerUrn, "key", 12);
-        createMetadataEntity("ownerA", ownerUrn, "key", 12);
-        createMetadataEntity("ownerC", ownerUrn, "key", 12);
-        createMetadataEntity("ownerB", ownerUrn, "key", 12);
-
-
-        Map<String, Object> keyValuePairMap = new HashMap<>();
-        keyValuePairMap.put("key", 12);
-
-        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByKeyValuePairs(tenantUrn, keyValuePairMap, 1, 10, SortOrder.ASC,
-            "ownerType");
-
-        assertEquals(4, responsePage.getData().size());
-        assertEquals(4, responsePage.getPage().getSize());
-        assertEquals(4, responsePage.getPage().getTotalElements());
-
-        assertEquals(1, responsePage.getPage().getNumber());
-        assertEquals(1, responsePage.getPage().getTotalPages());
-
-        assertEquals(ownerUrn, responsePage.getData().get(0).getOwnerUrn());
-        assertEquals("ownerA", responsePage.getData().get(0).getOwnerType());
-        assertEquals(ownerUrn, responsePage.getData().get(1).getOwnerUrn());
-        assertEquals("ownerB", responsePage.getData().get(1).getOwnerType());
-        assertEquals(ownerUrn, responsePage.getData().get(2).getOwnerUrn());
-        assertEquals("ownerC", responsePage.getData().get(2).getOwnerType());
-        assertEquals(ownerUrn, responsePage.getData().get(3).getOwnerUrn());
-        assertEquals("ownerD", responsePage.getData().get(3).getOwnerType());
-    }
-
-    @Test
     public void testFindBySingleKeyValuePairNonexistent() throws Exception {
 
         Map<String, Object> keyValuePairMap = new HashMap<>();
         keyValuePairMap.put("NoSuchKey", "NoSuchValue");
 
-        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByKeyValuePairs(tenantUrn, keyValuePairMap, 1, 10, null, null);
+        Page<MetadataOwnerResponse> responsePage = metadataPersistenceService.findOwnersByTypeAndKeyValuePairs(tenantUrn,
+            "someOwner", keyValuePairMap, 1, 10, null, null);
 
         assertTrue(responsePage.getData().isEmpty());
 

--- a/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
@@ -1,14 +1,13 @@
 package net.smartcosmos.dao.metadata.repository;
 
-import net.smartcosmos.dao.metadata.MetadataPersistenceConfig;
-import net.smartcosmos.dao.metadata.MetadataPersistenceTestApplication;
-import net.smartcosmos.dao.metadata.domain.MetadataDataType;
-import net.smartcosmos.dao.metadata.domain.MetadataEntity;
-import net.smartcosmos.dao.metadata.domain.MetadataOwnerEntity;
-import net.smartcosmos.util.UuidUtil;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.*;
+import org.junit.runner.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
@@ -18,7 +17,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import java.util.*;
+import net.smartcosmos.dao.metadata.MetadataPersistenceConfig;
+import net.smartcosmos.dao.metadata.MetadataPersistenceTestApplication;
+import net.smartcosmos.dao.metadata.domain.MetadataDataType;
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import net.smartcosmos.dao.metadata.domain.MetadataOwnerEntity;
+import net.smartcosmos.util.UuidUtil;
 
 import static org.junit.Assert.*;
 
@@ -136,7 +140,7 @@ public class MetadataRepositoryTest {
         }
 
 
-        Page<MetadataEntity> entityList = metadataRepository.findByOwner_TenantId(tenantId, new PageRequest(0, 1));
+        Page<MetadataEntity> entityList = metadataRepository.findByOwner_TenantIdAndOwner_Type(tenantId, "pageTest", new PageRequest(0, 1));
         assertFalse(entityList.getContent().isEmpty());
 
         assertEquals(1, entityList.getContent().size());


### PR DESCRIPTION
### What changes were proposed in this pull request?
- include `tenantUrn` in all responses
- add `ownerType` parameter to `findAll` (now `findByOwnerType`) and `findByKeyValuePairs`
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests.
#### Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-metadata/pull/22
