### PR TITLE
Fix page information in converter (for empty pages)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,15 @@
+= SMART COSMOS DAO Metadata for JPA Release Notes
+
+== UNRELEASED
+
+=== New Features
+
+No new features are added in this release.
+
+=== Bugfixes & Improvements
+
+* OBJECTS-979 Empty page response returns incorrect number of pages
+
+== Release 3.0.0 (August 12, 2016)
+
+Initial release.

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>net.smartcosmos</groupId>
                 <artifactId>smartcosmos-dao-metadata</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.1-SNAPSHOT</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/net/smartcosmos/dao/metadata/converter/SpringPageToPageInformationConverter.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/converter/SpringPageToPageInformationConverter.java
@@ -18,7 +18,7 @@ public class SpringPageToPageInformationConverter implements Converter<PageImpl<
             .number((page.getTotalElements() > 0 ? page.getNumber() + 1 : 0))
             .totalElements(page.getTotalElements())
             .size(page.getNumberOfElements())
-            .totalPages(page.getTotalPages())
+            .totalPages((page.getNumberOfElements() > 0 ? page.getTotalPages() : 0))
             .build();
     }
 

--- a/src/test/java/net/smartcosmos/dao/metadata/converter/SpringPageToPageInformationConverterTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/converter/SpringPageToPageInformationConverterTest.java
@@ -1,0 +1,61 @@
+package net.smartcosmos.dao.metadata.converter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.runners.*;
+import org.springframework.data.domain.PageImpl;
+
+import net.smartcosmos.dao.metadata.domain.MetadataEntity;
+import net.smartcosmos.dao.metadata.util.MetadataPersistenceUtil;
+import net.smartcosmos.dto.metadata.MetadataResponse;
+import net.smartcosmos.dto.metadata.Page;
+import net.smartcosmos.dto.metadata.PageInformation;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpringPageToPageInformationConverterTest {
+
+    @InjectMocks
+    SpringPageToPageInformationConverter converter;
+
+    @Test
+    public void testConversionService() throws Exception {
+
+        List<MetadataEntity> content = new ArrayList<>();
+        content.add(mock(MetadataEntity.class));
+        content.add(mock(MetadataEntity.class));
+
+        org.springframework.data.domain.PageImpl<MetadataEntity> entityPage = new PageImpl<>(content);
+        PageInformation page = converter.convert(entityPage);
+
+        assertNotNull(page);
+        assertEquals(1, page.getNumber());
+        assertEquals(2, page.getSize());
+        assertEquals(1, page.getTotalPages());
+        assertEquals(2, page.getTotalElements());
+    }
+
+    @Test
+    public void thatEmptyPageConversionSucceeds() {
+
+        List<MetadataEntity> content = new ArrayList<>();
+
+        org.springframework.data.domain.PageImpl<MetadataEntity> entityPage = new PageImpl<>(content);
+        PageInformation page = converter.convert(entityPage);
+
+        assertNotNull(page);
+        assertEquals(0, page.getSize());
+        assertEquals(0, page.getNumber());
+        assertEquals(0, page.getTotalPages());
+        assertEquals(0, page.getTotalElements());
+
+        Page<MetadataResponse> emptyPage = MetadataPersistenceUtil.emptyPage();
+        assertEquals(emptyPage.getPage(), page);
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fixes the empty page response, which previously contained incorrect values for `totalPages` and `number`.

Also makes sure, that the page information aren't `null` when using the builder.
### How is this patch documented?

Code.
### How was this patch tested?

Unit tests.
#### Depends On

Builder fix in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-metadata/pull/25 (merged)
