### PR TITLE
Moves to next framework version and removes unnecessary versions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.smartcosmos</groupId>
         <artifactId>smartcosmos-framework-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
     <artifactId>smartcosmos-dao-metadata-default</artifactId>
@@ -27,12 +27,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>
             <artifactId>java-uuid-generator</artifactId>
-            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.json</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Just to avoid any chance of an old version of the framework sneaking into a package, this pushes the default to the next version.
