### PR TITLE
Persist metadata changes and always put entries, not just if absent

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,7 @@ No new features are added in this release.
 === Bugfixes & Improvements
 
 * OBJECTS-979 Empty page response returns incorrect number of pages
+* OBJECTS-1009 Upsert Metadata has no effect on existing entries
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataOwnerRepositoryImpl.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataOwnerRepositoryImpl.java
@@ -44,8 +44,9 @@ public class MetadataOwnerRepositoryImpl implements MetadataOwnerRepositoryCusto
         for (MetadataEntity metadataEntity : metadataEntities) {
             metadataEntity.setOwner(owner);
 
-            ownerMetadataEntities.putIfAbsent(metadataEntity.getKeyName(), metadataEntity);
+            ownerMetadataEntities.put(metadataEntity.getKeyName(), metadataEntity);
         }
+        persist(owner);
     }
 
     @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Metadata update had no effect, because entries were only added if they didn't previously exist, and potential changes were not persisted in the end.
### How is this patch documented?

Code.
### How was this patch tested?

manually in Postman
#### Depends On

Nothing.
