### PR TITLE
Bugfix/profiles 706

### DIFF
--- a/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/repository/MetadataRepository.java
@@ -34,6 +34,11 @@ public interface MetadataRepository extends JpaRepository<MetadataEntity, UUID>,
         UUID ownerId,
         String keyName);
 
+    Optional<MetadataEntity> findByOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(
+        String ownerType,
+        UUID ownerId,
+        String keyName);
+
     Page<MetadataEntity> findByOwner_TenantIdAndOwner_Type(UUID ownerId, String ownerType, Pageable pageable);
 
     List<MetadataEntity> findByOwner_TenantIdAndOwner_TypeAndOwner_Id(UUID tenantId, String ownerType, UUID ownerId);

--- a/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
@@ -517,6 +517,46 @@ public class MetadataPersistenceServiceTest {
 
     // endregion */
 
+    // region Find by Key No Tenant
+
+    @Test
+    public void testFindByKeyNoTenant() {
+
+        final String keyName = "findMeNoTenant";
+        final Boolean value = true;
+        final String ownerType = "Thing";
+        final String ownerUrn = UuidUtil.getThingUrnFromUuid(UUID.randomUUID());
+
+        Map<String, Object> keyValues = new HashMap<>();
+        keyValues.put(keyName, value);
+
+        metadataPersistenceService.create(tenantUrn, ownerType, ownerUrn, keyValues);
+
+        Optional<MetadataValueResponse> response = metadataPersistenceService.findByKeyNoTenant(ownerType, ownerUrn, keyName);
+
+        assertTrue(response.isPresent());
+        assertEquals(true,
+                     response.get()
+                         .getValue());
+        assertEquals(tenantUrn,
+                     response.get()
+                         .getTenantUrn());
+    }
+
+    @Test
+    public void testFindByKeyNoTenantNonexistent() {
+
+        final String keyName = "this-does-not-existNoTenant";
+        final String ownerType = "Thing";
+        final String ownerUrn = UuidUtil.getThingUrnFromUuid(UUID.randomUUID());
+
+        Optional<MetadataValueResponse> response = metadataPersistenceService.findByKeyNoTenant(ownerType, ownerUrn, keyName);
+
+        assertFalse(response.isPresent());
+    }
+
+    // endregion */
+
     // region Find by Owner
 
     @Test

--- a/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/repository/MetadataRepositoryTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.*;
 @ActiveProfiles("test")
 @WebAppConfiguration
 @IntegrationTest({ "spring.cloud.config.enabled=false", "eureka.client.enabled:false" })
+@SuppressWarnings("duplicates")
 public class MetadataRepositoryTest {
 
     @Autowired
@@ -99,6 +100,27 @@ public class MetadataRepositoryTest {
                                                                                                                               ownerType,
                                                                                                                               ownerId,
                                                                                                                               keyName);
+
+        assertTrue(entity.isPresent());
+
+        assertEquals("true",
+                     entity.get()
+                         .getValue());
+        assertEquals("Boolean",
+                     entity.get()
+                         .getDataType()
+                         .toString());
+        assertEquals(keyName,
+                     entity.get()
+                         .getKeyName());
+    }
+
+    @Test
+    public void thatFindByKeyNoTenantIsSuccessful() throws Exception {
+
+        Optional<MetadataEntity> entity = metadataRepository.findByOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(ownerType,
+                                                                                                             ownerId,
+                                                                                                             keyName);
 
         assertTrue(entity.isPresent());
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
- add support for GET /{ownerType}/{ownerUrn}/{key}?ignoreUserTenant={ignoreUserTenant}&tenantUrn={tenantUrn} on the DAO interface, when ignoreUserTenant = true and tenantUrn is empty
- this fixes the problem of some PROFILES services to read metadata of a thing independently of the tenant
- the fix is not directly related to OBJECTS, but updating the DAO interface will break the OBJECTS DAO implementation if the fix is not applied
### How is this patch documented?

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-ext-metadata-rdao/blob/bugfix/PROFILES-706/README.adoc#read1

The service uses following rule to look up a metadata key:
1. when the user has https://authorities.smartcosmos.net/metadata/ignoreUserTenant authority and ignoreUserTenant is set to true
  a) if tenantUrn is given: return metadata of the thing defined by type, urn in the given tenant
  b) if tenantUrn is empty: return metadata of the thing defined by type, urn in any tenant
2. when the user does not have this authority or ignoreUserTenant is false:
return metadata of the thing defined by type, urn in the tenant related to the user's login credentials
### How was this patch tested?
- JUnit tests updated
#### Depends On
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-dao-metadata/pull/26
