### PR TITLE
Bugfix/objects 1007

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ No new features are added in this release.
 
 * OBJECTS-979 Empty page response returns incorrect number of pages
 * OBJECTS-1009 Upsert Metadata has no effect on existing entries
+* OBJECTS-1007 Invalid URN scheme results in 500 response, and URN scheme is not checked correctly
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,9 @@
 = SMART COSMOS DAO Metadata for JPA
 
+ifdef::env-github[:USER: SMARTRACTECHNOLOGY]
+ifdef::env-github[:REPO: smartcosmos-dao-metadata-default]
+ifdef::env-github[:BRANCH: master]
+
+image::https://jenkins.smartcosmos.net/buildStatus/icon?job={USER}/{REPO}/{BRANCH}[Build Status, link=https://jenkins.smartcosmos.net/job/{USER}/job/{REPO}/job/{BRANCH}/]
+
 Implementation of the Metadata DAO for JPA (relational databases).  This is an example implementation that defines a historical database structure closely resembling previous versions of Objects to facilitate a migration pattern for those moving into the next major release.

--- a/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceService.java
@@ -189,14 +189,9 @@ public class MetadataPersistenceService implements MetadataDao {
         UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
         List<MetadataEntity> deleteList = new ArrayList<>();
 
-        try {
-            UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
-            deleteList = metadataRepository.deleteByOwner_TenantIdAndOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(tenantId, ownerType, ownerId, key);
-            ownerRepository.orphanDelete(tenantId, ownerType, ownerId);
-        } catch (IllegalArgumentException e) {
-            // empty list will be returned anyway
-            log.warn("Illegal URN submitted: {} by tenant {}", ownerUrn, tenantUrn);
-        }
+        UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
+        deleteList = metadataRepository.deleteByOwner_TenantIdAndOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(tenantId, ownerType, ownerId, key);
+        ownerRepository.orphanDelete(tenantId, ownerType, ownerId);
 
         return convertList(deleteList, MetadataEntity.class, MetadataResponse.class);
     }
@@ -207,16 +202,11 @@ public class MetadataPersistenceService implements MetadataDao {
         UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
         List<MetadataEntity> deleteList = new ArrayList<>();
 
-        try {
-            UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
-            List<MetadataOwnerEntity> ownerList = ownerRepository.deleteByTenantIdAndTypeIgnoreCaseAndId(tenantId, ownerType, ownerId);
-            if (!ownerList.isEmpty()) {
-                deleteList.addAll(ownerList.get(0)
-                                      .getAllMetadataEntities());
-            }
-        } catch (IllegalArgumentException e) {
-            // empty list will be returned anyway
-            log.warn("Illegal URN submitted: {} by tenant {}", ownerUrn, tenantUrn);
+        UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
+        List<MetadataOwnerEntity> ownerList = ownerRepository.deleteByTenantIdAndTypeIgnoreCaseAndId(tenantId, ownerType, ownerId);
+        if (!ownerList.isEmpty()) {
+            deleteList.addAll(ownerList.get(0)
+                                  .getAllMetadataEntities());
         }
 
         return convertList(deleteList, MetadataEntity.class, MetadataResponse.class);
@@ -225,27 +215,22 @@ public class MetadataPersistenceService implements MetadataDao {
     @Override
     public Optional<MetadataValueResponse> findByKey(String tenantUrn, String ownerType, String ownerUrn, String key) {
 
-        try {
-            UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
-            UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
+        UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
+        UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
 
-            Optional<MetadataEntity> entity = metadataRepository.findByOwner_TenantIdAndOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(tenantId,
-                                                                                                                                  ownerType,
-                                                                                                                                  ownerId,
-                                                                                                                                  key);
+        Optional<MetadataEntity> entity = metadataRepository.findByOwner_TenantIdAndOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(tenantId,
+                                                                                                                              ownerType,
+                                                                                                                              ownerId,
+                                                                                                                              key);
 
-            if (entity.isPresent()) {
-                Object value = MetadataValueParser.parseValue(entity.get());
-                String responseTenantUrn = UuidUtil.getTenantUrnFromUuid(entity.get()
-                                                                             .getOwner()
-                                                                             .getTenantId());
-                MetadataValueResponse response = new MetadataValueResponse(value, responseTenantUrn);
+        if (entity.isPresent()) {
+            Object value = MetadataValueParser.parseValue(entity.get());
+            String responseTenantUrn = UuidUtil.getTenantUrnFromUuid(entity.get()
+                                                                         .getOwner()
+                                                                         .getTenantId());
+            MetadataValueResponse response = new MetadataValueResponse(value, responseTenantUrn);
 
-                return Optional.ofNullable(response);
-            }
-        } catch (IllegalArgumentException e) {
-            // empty Optional will be returned anyway
-            log.warn("Illegal URN submitted: %s by account %s", ownerUrn, tenantUrn);
+            return Optional.ofNullable(response);
         }
 
         return Optional.empty();
@@ -254,25 +239,20 @@ public class MetadataPersistenceService implements MetadataDao {
     @Override
     public Optional<MetadataValueResponse> findByKeyNoTenant(String ownerType, String ownerUrn, String key) {
 
-        try {
-            UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
+        UUID ownerId = UuidUtil.getUuidFromUrn(ownerUrn);
 
-            Optional<MetadataEntity> entity = metadataRepository.findByOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(ownerType,
-                                                                                                                 ownerId,
-                                                                                                                 key);
+        Optional<MetadataEntity> entity = metadataRepository.findByOwner_TypeAndOwner_IdAndKeyNameIgnoreCase(ownerType,
+                                                                                                             ownerId,
+                                                                                                             key);
 
-            if (entity.isPresent()) {
-                Object value = MetadataValueParser.parseValue(entity.get());
-                String responseTenantUrn = UuidUtil.getTenantUrnFromUuid(entity.get()
-                                                                             .getOwner()
-                                                                             .getTenantId());
-                MetadataValueResponse response = new MetadataValueResponse(value, responseTenantUrn);
+        if (entity.isPresent()) {
+            Object value = MetadataValueParser.parseValue(entity.get());
+            String responseTenantUrn = UuidUtil.getTenantUrnFromUuid(entity.get()
+                                                                         .getOwner()
+                                                                         .getTenantId());
+            MetadataValueResponse response = new MetadataValueResponse(value, responseTenantUrn);
 
-                return Optional.ofNullable(response);
-            }
-        } catch (IllegalArgumentException e) {
-            // empty Optional will be returned anyway
-            log.warn("Illegal URN submitted: %s", ownerUrn);
+            return Optional.ofNullable(response);
         }
 
         return Optional.empty();
@@ -394,18 +374,11 @@ public class MetadataPersistenceService implements MetadataDao {
 
     private Page<MetadataSingleResponse> findByOwnerTypePage(String tenantUrn, String ownerType, Pageable pageable) {
 
-        Page<MetadataSingleResponse> result = MetadataPersistenceUtil.emptyPage();
-        try {
-            UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
-            org.springframework.data.domain.Page<MetadataEntity> pageEntity = metadataRepository
-                .findByOwner_TenantIdAndOwner_Type(tenantId, ownerType, pageable);
+        UUID tenantId = UuidUtil.getUuidFromUrn(tenantUrn);
+        org.springframework.data.domain.Page<MetadataEntity> pageEntity = metadataRepository
+            .findByOwner_TenantIdAndOwner_Type(tenantId, ownerType, pageable);
 
-            return convertPage(pageEntity, MetadataEntity.class, MetadataSingleResponse.class);
-        } catch (IllegalArgumentException e) {
-            log.warn("Error processing URN: Tenant URN '{}'", tenantUrn);
-        }
-
-        return result;
+        return convertPage(pageEntity, MetadataEntity.class, MetadataSingleResponse.class);
     }
 
     /**

--- a/src/main/java/net/smartcosmos/dao/metadata/util/UuidUtil.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/util/UuidUtil.java
@@ -19,7 +19,7 @@ public class UuidUtil {
 
     public static UUID getUuidFromUrn(String urn) throws IllegalArgumentException {
 
-        String urnScheme = "urn:.*:uuid:([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})";
+        String urnScheme = "^urn:.*:uuid:([A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12})$";
 
         Pattern p = Pattern.compile(urnScheme, Pattern.CASE_INSENSITIVE);
         Matcher m = p.matcher(urn);

--- a/src/test/java/net/smartcosmos/dao/metadata/util/UuidUtilTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/util/UuidUtilTest.java
@@ -26,6 +26,20 @@ public class UuidUtilTest {
         UuidUtil.getUuidFromUrn(urn);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void getUuidFromInvaldiUrnPrefix() throws Exception {
+
+        final String urn = "INVALID-urn:thing:uuid:8e24eabd-1be9-46ac-8c7d-1e753746b413";
+        UuidUtil.getUuidFromUrn(urn);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void getUuidFromInvaldiUrnSuffix() throws Exception {
+
+        final String urn = "urn:thing:uuid:8e24eabd-1be9-46ac-8c7d-1e753746b413-INVALID";
+        UuidUtil.getUuidFromUrn(urn);
+    }
+
     @Test
     public void getThingUrnFromUuid() throws Exception {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
- removes `try {} catch ()` blocks for `IllegalArgumentException` because they never really worked, and the exceptions are now handled in Framework's `RequestExceptionHandler` controller advice
- fixes the URN scheme, so that `bogus_<valid URN>` or `<valid URN>_bogus` is not valid anymore
- adds Jenkins build status 😎 
### How is this patch documented?

Code
### How was this patch tested?

existing unit tests
#### Depends On

`RequestExceptionHandler` controller advice in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/198
