### PR TITLE
removed objectMapper.enableDefaultTyping() calls from MetadataValuePa…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ No new features are added in this release.
 * OBJECTS-979 Empty page response returns incorrect number of pages
 * OBJECTS-1009 Upsert Metadata has no effect on existing entries
 * OBJECTS-1007 Invalid URN scheme results in 500 response, and URN scheme is not checked correctly
+* OBJECTS-1105 mapper.enableDefaultTyping() removed, was generating extraneous info in stored JSON
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/dao/metadata/util/MetadataValueParser.java
+++ b/src/main/java/net/smartcosmos/dao/metadata/util/MetadataValueParser.java
@@ -49,7 +49,6 @@ public class MetadataValueParser {
                 case JSON_ARRAY:
                 case JSON_OBJECT:
                     ObjectMapper mapper = new ObjectMapper();
-                    mapper.enableDefaultTyping();
                     try {
                         return mapper.readTree(entity.getValue());
                     } catch (IOException e) {
@@ -81,7 +80,6 @@ public class MetadataValueParser {
                 (MetadataDataType.JSON_ARRAY == getDataType(object))) {
 
                 ObjectMapper mapper = new ObjectMapper();
-                mapper.enableDefaultTyping();
                 try {
                     return mapper.writeValueAsString(object);
                 } catch (JsonProcessingException e) {

--- a/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
+++ b/src/test/java/net/smartcosmos/dao/metadata/impl/MetadataPersistenceServiceTest.java
@@ -174,6 +174,232 @@ public class MetadataPersistenceServiceTest {
     }
 
     @Test
+    public void testCreateWithComplexJsonMetadataValue() throws Exception {
+
+        final String ownerType = "Thing";
+        final String ownerUrn = UuidUtil.getThingUrnFromUuid(UUID.randomUUID());
+
+        final JSONObject jsonObject = new JSONObject("{ \"frog\" : \"bog\", \"log\" : { \"dog\" : \"hog\", \"flog\" : { \"grog\" : \"mog\" } } }");
+        final String jsonAsString = "{ \"frog\" : \"bog\", \"log\" : { \"dog\" : \"hog\", \"flog\" : { \"grog\" : \"mog\" } } }";
+
+        Map<String, Object> keyValues = new HashMap<>();
+        keyValues.put("someJsonObject", jsonObject);
+        keyValues.put("someJsonObjectAsString", jsonAsString);
+
+        Optional<MetadataResponse> response = metadataPersistenceService.create(tenantUrn, ownerType, ownerUrn, keyValues);
+
+        assertTrue(response.isPresent());
+        assertEquals(ownerType,
+                     response.get()
+                         .getOwnerType());
+        assertEquals(ownerUrn,
+                     response.get()
+                         .getOwnerUrn());
+
+        assertEquals(2,
+                     response.get()
+                         .getMetadata()
+                         .size());
+
+        assertEquals(jsonObject.toString(),
+                     response.get()
+                         .getMetadata()
+                         .get("someJsonObject")
+                         .toString());
+
+        assertEquals(jsonAsString,
+                     response.get()
+                         .getMetadata()
+                         .get("someJsonObjectAsString")
+                         .toString());
+
+        List<MetadataEntity> entityList = metadataRepository.findByOwner_TenantIdAndOwner_TypeAndOwner_Id(tenantId,
+                                                                                                          ownerType,
+                                                                                                          UuidUtil.getUuidFromUrn(ownerUrn));
+
+        assertFalse(entityList.isEmpty());
+
+        assertFalse(entityList.isEmpty());
+        assertEquals(2, entityList.size());
+    }
+
+    @Test
+    public void testCreateWithComplexJsonMetadataValue2() throws Exception {
+
+        final String ownerType = "Thing";
+        final String ownerUrn = UuidUtil.getThingUrnFromUuid(UUID.randomUUID());
+
+        final JSONObject jsonObject = new JSONObject("{\n"
+                                                     + "    \"minH\": 6,\n"
+                                                     + "    \"minW\": 6,\n"
+                                                     + "    \"x\": 0,\n"
+                                                     + "    \"y\": 0,\n"
+                                                     + "    \"w\": 6,\n"
+                                                     + "    \"h\": 6,\n"
+                                                     + "    \"static\": false,\n"
+                                                     + "    \"state\": {\n"
+                                                     + "        \"type\": \"\",\n"
+                                                     + "        \"title\": \"\",\n"
+                                                     + "        \"configuration\": {\n"
+                                                     + "            \"chartType\": \"bar\"\n"
+                                                     + "        }\n"
+                                                     + "     }\n"
+                                                     + "   }\n"
+                                                     + "    \"maxH\": 8,\n"
+                                                     + "    \"maxW\": 8,\n"
+                                                     + "}");
+
+        final String jsonAsString = "{\n"
+                                    + "    \"minH\": 6,\n"
+                                    + "    \"minW\": 6,\n"
+                                    + "    \"x\": 0,\n"
+                                    + "    \"y\": 0,\n"
+                                    + "    \"w\": 6,\n"
+                                    + "    \"h\": 6,\n"
+                                    + "    \"static\": false,\n"
+                                    + "    \"state\": {\n"
+                                    + "        \"type\": \"\",\n"
+                                    + "        \"title\": \"\",\n"
+                                    + "        \"configuration\": {\n"
+                                    + "            \"chartType\": \"bar\"\n"
+                                    + "        }\n"
+                                    + "     }\n"
+                                    + "   }\n"
+                                    + "    \"maxH\": 8,\n"
+                                    + "    \"maxW\": 8,\n"
+                                    + "}";
+
+        Map<String, Object> keyValues = new HashMap<>();
+        keyValues.put("someJsonObjectAsString", jsonAsString);
+        keyValues.put("someJsonObject", jsonObject);
+
+        Optional<MetadataResponse> response = metadataPersistenceService.create(tenantUrn, ownerType, ownerUrn, keyValues);
+
+        Optional<MetadataValueResponse> getResponseJsonObject = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, "someJsonObject");
+        Optional<MetadataValueResponse> getResponseJsonObjectAsString = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, "someJsonObjectAsString");
+
+        assertTrue(response.isPresent());
+        assertEquals(ownerType,
+                     response.get()
+                         .getOwnerType());
+        assertEquals(ownerUrn,
+                     response.get()
+                         .getOwnerUrn());
+
+        assertEquals(2,
+                     response.get()
+                         .getMetadata()
+                         .size());
+
+        assertEquals(jsonObject.toString(),
+                     response.get()
+                         .getMetadata()
+                         .get("someJsonObject")
+                         .toString());
+
+        assertEquals(jsonAsString,
+                     response.get()
+                         .getMetadata()
+                         .get("someJsonObjectAsString")
+                         .toString());
+
+        List<MetadataEntity> entityList = metadataRepository.findByOwner_TenantIdAndOwner_TypeAndOwner_Id(tenantId,
+                                                                                                          ownerType,
+                                                                                                          UuidUtil.getUuidFromUrn(ownerUrn));
+
+        assertFalse(entityList.isEmpty());
+
+        assertFalse(entityList.isEmpty());
+        assertEquals(2, entityList.size());
+    }
+
+    @Test
+    public void testCreateWithComplexJsonMetadataValue3() throws Exception {
+
+        final String ownerType = "Thing";
+        final String ownerUrn = UuidUtil.getThingUrnFromUuid(UUID.randomUUID());
+
+        final JSONObject jsonObject = new JSONObject("{\n"
+                                                     + "    \"lastUpdatedAt\":\"2016-11-17T01:55:02.187Z\",\n"
+                                                     + "    \"w\":6,\n"
+                                                     + "    \"h\":6,\n"
+                                                     + "    \"x\":6,\n"
+                                                     + "    \"y\":0,\n"
+                                                     + "    \"minW\":4,\n"
+                                                     + "    \"minH\":4,\n"
+                                                     + "    \"moved\":false,\n"
+                                                     + "    \"static\":false,\n"
+                                                     + "    \"state\": {\n"
+                                                     + "        \"title\": \"asdasda\",\n"
+                                                     + "         \"configuration\": {\n"
+                                                     + "             \"metricType\": \"chart\"\n"
+                                                     + "         }\n"
+                                                     + "    }\n"
+                                                     + "}");
+
+        final String jsonAsString = "{\n"
+                                    + "    \"lastUpdatedAt\":\"2016-11-17T01:55:02.187Z\",\n"
+                                    + "    \"w\":6,\n"
+                                    + "    \"h\":6,\n"
+                                    + "    \"x\":6,\n"
+                                    + "    \"y\":0,\n"
+                                    + "    \"minW\":4,\n"
+                                    + "    \"minH\":4,\n"
+                                    + "    \"moved\":false,\n"
+                                    + "    \"static\":false,\n"
+                                    + "    \"state\": {\n"
+                                    + "        \"title\": \"asdasda\",\n"
+                                    + "         \"configuration\": {\n"
+                                    + "             \"metricType\": \"chart\"\n"
+                                    + "         }\n"
+                                    + "    }\n"
+                                    + "}";
+
+        Map<String, Object> keyValues = new HashMap<>();
+        keyValues.put("someJsonObjectAsString", jsonAsString);
+        keyValues.put("someJsonObject", jsonObject);
+
+        Optional<MetadataResponse> response = metadataPersistenceService.create(tenantUrn, ownerType, ownerUrn, keyValues);
+
+        Optional<MetadataValueResponse> getResponseJsonObject = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, "someJsonObject");
+        Optional<MetadataValueResponse> getResponseJsonObjectAsString = metadataPersistenceService.findByKey(tenantUrn, ownerType, ownerUrn, "someJsonObjectAsString");
+
+        assertTrue(response.isPresent());
+        assertEquals(ownerType,
+                     response.get()
+                         .getOwnerType());
+        assertEquals(ownerUrn,
+                     response.get()
+                         .getOwnerUrn());
+
+        assertEquals(2,
+                     response.get()
+                         .getMetadata()
+                         .size());
+
+        assertEquals(jsonObject.toString(),
+                     response.get()
+                         .getMetadata()
+                         .get("someJsonObject")
+                         .toString());
+
+        assertEquals(jsonAsString,
+                     response.get()
+                         .getMetadata()
+                         .get("someJsonObjectAsString")
+                         .toString());
+
+        List<MetadataEntity> entityList = metadataRepository.findByOwner_TenantIdAndOwner_TypeAndOwner_Id(tenantId,
+                                                                                                          ownerType,
+                                                                                                          UuidUtil.getUuidFromUrn(ownerUrn));
+
+        assertFalse(entityList.isEmpty());
+
+        assertFalse(entityList.isEmpty());
+        assertEquals(2, entityList.size());
+    }
+
+    @Test
     public void testCreateFailOnDuplicateKey() {
 
         final String ownerType = "Thing";


### PR DESCRIPTION
### What changes were proposed in this pull request?

removed calls to objectMapper.enableDefaultTyping(),  which was adding Java typing info to stored JSON.

### How is this patch documented?

Code.

### How was this patch tested?

Postman, existing unit tests.


#### Depends On

Nothing.
