### PR TITLE
Bugfix/objects 1109

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@ No new features are added in this release.
 * OBJECTS-1009 Upsert Metadata has no effect on existing entries
 * OBJECTS-1007 Invalid URN scheme results in 500 response, and URN scheme is not checked correctly
 * OBJECTS-1105 mapper.enableDefaultTyping() removed, was generating extraneous info in stored JSON
+* OBJECTS-1109 Ext Metadata returns Internal Server Error in case of constraint violation
 
 == Release 3.0.0 (August 12, 2016)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Constraint violations were not properly handled in the Metadata persistence layer, so that the RDAO returned an Internal Server Error, because it didn't get the expected `ConstraintViolationException` but some sub type of `TransactionException`.

The reason for that is, that we only caught exceptions that occur when the Metadata owner is persisted, but the entities themselves are persisted by some _magic code_ we don't control and therefore also didn't catch the exceptions for.

This adds an additional `catch` block and exception handling where the Metadata entries are added to the owner -- the exception pops up into our scope there.

### How is this patch documented?

- Code
- Code comments

### How was this patch tested?

manually in Postman

#### Depends On

Nothing.